### PR TITLE
support userData in noise payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const CAP_NS_BUF = Buffer.from('hypercore capability')
 
 module.exports = class SimpleProtocol {
   constructor (initiator, handlers) {
-    const payload = { nonce: XOR.nonce() }
+    const payload = { nonce: XOR.nonce(), userData: handlers.userData }
     const handshake = new Handshake(initiator, messages.NoisePayload.encode(payload), handlers, this._onhandshake.bind(this))
 
     this.handlers = handlers || {}
@@ -18,6 +18,9 @@ module.exports = class SimpleProtocol {
     this.remotePublicKey = null
     this.publicKey = handshake.keyPair.publicKey
     this.destroyed = false
+
+    this.remoteUserData = null
+    this.userData = handlers.userData || null
 
     this._payload = payload
     this._pending = []
@@ -127,6 +130,8 @@ module.exports = class SimpleProtocol {
       : new XOR({ rnonce: remotePayload.nonce, tnonce: this._payload.nonce }, split)
 
     this.remotePayload = remotePayload
+    this.remoteUserData = remotePayload.userData
+
     if (this.handlers.onhandshake) this.handlers.onhandshake()
     if (this.destroyed) return
 

--- a/messages.js
+++ b/messages.js
@@ -108,8 +108,93 @@ defineData()
 defineClose()
 
 function defineNoisePayload () {
+  var UserData = NoisePayload.UserData = {
+    buffer: true,
+    encodingLength: null,
+    encode: null,
+    decode: null
+  }
+
+  defineUserData()
+
+  function defineUserData () {
+    var enc = [
+      encodings.string,
+      encodings.bytes
+    ]
+
+    UserData.encodingLength = encodingLength
+    UserData.encode = encode
+    UserData.decode = decode
+
+    function encodingLength (obj) {
+      var length = 0
+      if (!defined(obj.type)) throw new Error("type is required")
+      var len = enc[0].encodingLength(obj.type)
+      length += 1 + len
+      if (defined(obj.value)) {
+        var len = enc[1].encodingLength(obj.value)
+        length += 1 + len
+      }
+      return length
+    }
+
+    function encode (obj, buf, offset) {
+      if (!offset) offset = 0
+      if (!buf) buf = Buffer.allocUnsafe(encodingLength(obj))
+      var oldOffset = offset
+      if (!defined(obj.type)) throw new Error("type is required")
+      buf[offset++] = 10
+      enc[0].encode(obj.type, buf, offset)
+      offset += enc[0].encode.bytes
+      if (defined(obj.value)) {
+        buf[offset++] = 18
+        enc[1].encode(obj.value, buf, offset)
+        offset += enc[1].encode.bytes
+      }
+      encode.bytes = offset - oldOffset
+      return buf
+    }
+
+    function decode (buf, offset, end) {
+      if (!offset) offset = 0
+      if (!end) end = buf.length
+      if (!(end <= buf.length && offset <= buf.length)) throw new Error("Decoded message is not valid")
+      var oldOffset = offset
+      var obj = {
+        type: "",
+        value: null
+      }
+      var found0 = false
+      while (true) {
+        if (end <= offset) {
+          if (!found0) throw new Error("Decoded message is not valid")
+          decode.bytes = offset - oldOffset
+          return obj
+        }
+        var prefix = varint.decode(buf, offset)
+        offset += varint.decode.bytes
+        var tag = prefix >> 3
+        switch (tag) {
+          case 1:
+          obj.type = enc[0].decode(buf, offset)
+          offset += enc[0].decode.bytes
+          found0 = true
+          break
+          case 2:
+          obj.value = enc[1].decode(buf, offset)
+          offset += enc[1].decode.bytes
+          break
+          default:
+          offset = skip(prefix & 7, buf, offset)
+        }
+      }
+    }
+  }
+
   var enc = [
-    encodings.bytes
+    encodings.bytes,
+    UserData
   ]
 
   NoisePayload.encodingLength = encodingLength
@@ -121,6 +206,11 @@ function defineNoisePayload () {
     if (!defined(obj.nonce)) throw new Error("nonce is required")
     var len = enc[0].encodingLength(obj.nonce)
     length += 1 + len
+    if (defined(obj.userData)) {
+      var len = enc[1].encodingLength(obj.userData)
+      length += varint.encodingLength(len)
+      length += 1 + len
+    }
     return length
   }
 
@@ -132,6 +222,13 @@ function defineNoisePayload () {
     buf[offset++] = 10
     enc[0].encode(obj.nonce, buf, offset)
     offset += enc[0].encode.bytes
+    if (defined(obj.userData)) {
+      buf[offset++] = 18
+      varint.encode(enc[1].encodingLength(obj.userData), buf, offset)
+      offset += varint.encode.bytes
+      enc[1].encode(obj.userData, buf, offset)
+      offset += enc[1].encode.bytes
+    }
     encode.bytes = offset - oldOffset
     return buf
   }
@@ -142,7 +239,8 @@ function defineNoisePayload () {
     if (!(end <= buf.length && offset <= buf.length)) throw new Error("Decoded message is not valid")
     var oldOffset = offset
     var obj = {
-      nonce: null
+      nonce: null,
+      userData: null
     }
     var found0 = false
     while (true) {
@@ -159,6 +257,12 @@ function defineNoisePayload () {
         obj.nonce = enc[0].decode(buf, offset)
         offset += enc[0].decode.bytes
         found0 = true
+        break
+        case 2:
+        var len = varint.decode(buf, offset)
+        offset += varint.decode.bytes
+        obj.userData = enc[1].decode(buf, offset, offset + len)
+        offset += enc[1].decode.bytes
         break
         default:
         offset = skip(prefix & 7, buf, offset)

--- a/schema.proto
+++ b/schema.proto
@@ -1,6 +1,12 @@
 // Sent as part of the noise protocol.
 message NoisePayload {
+  message UserData {
+    required string type = 1;
+    optional bytes value = 2;
+  }
+
   required bytes nonce = 1;
+  optional UserData userData = 2;
 }
 
 // type=0


### PR DESCRIPTION
Support passing a user defined object that looks like this { type: 'some-string', data: <some buffer> } as part of the connection handshake