### PR TITLE
Optionally disable NOISE

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to ensure your stream is private.
 
 To disable transport encryption set `handlers.encrypted = false`.
 
-To disable both the NOISE handshake and the transport encryption, set `handlers.noise = false`.
+To disable the NOISE handshake set `handlers.noise = false` (works only when `encrypted` is also set to false).
 
 #### `p.recv(data)`
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ to ensure your stream is private.
 
 To disable transport encryption set `handlers.encrypted = false`.
 
+To disable both the NOISE handshake and the transport encryption, set `handlers.noise = false`.
+
 #### `p.recv(data)`
 
 Call this with incoming data.

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = class SimpleProtocol {
     this._handshake = null
     this._split = null
     this._encryption = null
+    this._noise = !(handlers.encrypted === false && handlers.noise === false)
     this._buffering = null
 
     this._messages = new SMC({
@@ -45,7 +46,9 @@ module.exports = class SimpleProtocol {
       ]
     })
 
-    if (this.handlers.noise !== false) {
+    if (handlers.encrypted === false && handlers.noise === false) {
+      this._handshaking = false
+    } else {
       this._handshaking = true
       if (typeof this.handlers.keyPair !== 'function') {
         this._onkeypair(null, this.handlers.keyPair || null)
@@ -53,8 +56,6 @@ module.exports = class SimpleProtocol {
         this._buffering = []
         this.handlers.keyPair(this._onkeypair.bind(this))
       }
-    } else {
-      this._handshaking = false
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports = class SimpleProtocol {
     this._payload = payload
     this._pending = []
     this._handshake = null
-    this._handshaking = true
     this._split = null
     this._encryption = null
     this._buffering = null
@@ -46,11 +45,16 @@ module.exports = class SimpleProtocol {
       ]
     })
 
-    if (typeof this.handlers.keyPair !== 'function') {
-      this._onkeypair(null, this.handlers.keyPair || null)
+    if (this.handlers.noise !== false) {
+      this._handshaking = true
+      if (typeof this.handlers.keyPair !== 'function') {
+        this._onkeypair(null, this.handlers.keyPair || null)
+      } else {
+        this._buffering = []
+        this.handlers.keyPair(this._onkeypair.bind(this))
+      }
     } else {
-      this._buffering = []
-      this.handlers.keyPair(this._onkeypair.bind(this))
+      this._handshaking = false
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = class SimpleProtocol {
     this._encryption = null
     this._noise = !(handlers.encrypted === false && handlers.noise === false)
     this._buffering = null
+    this._handshaking = false
 
     this._messages = new SMC({
       onmessage,
@@ -45,10 +46,8 @@ module.exports = class SimpleProtocol {
         { context: this, onmessage: onclose, encoding: messages.Close }
       ]
     })
-
-    if (handlers.encrypted === false && handlers.noise === false) {
-      this._handshaking = false
-    } else {
+    
+    if (handlers.encrypted !== false || handlers.noise !== false) {
       this._handshaking = true
       if (typeof this.handlers.keyPair !== 'function') {
         this._onkeypair(null, this.handlers.keyPair || null)

--- a/test.js
+++ b/test.js
@@ -221,3 +221,33 @@ tape('set key pair later', function (t) {
     }
   })
 })
+
+tape('disable noise', function (t) {
+  const a = new SHP(true, {
+    noise: false,
+    onhandshake () {
+      t.fail('onhandshake may not be called with noise: false')
+    },
+    send (data) {
+      b.recv(data)
+    }
+  })
+
+  const b = new SHP(false, {
+    noise: false,
+    onhandshake () {
+      t.fail('onhandshake may not be called with noise: false')
+    },
+    onopen (ch, message) {
+      t.same(ch, 0)
+      t.same(message.discoveryKey, discoveryKey)
+      t.notOk(message.key)
+      t.end()
+    },
+    send (data) {
+      a.recv(data)
+    }
+  })
+
+  a.open(0, { key, discoveryKey })
+})

--- a/test.js
+++ b/test.js
@@ -225,6 +225,7 @@ tape('set key pair later', function (t) {
 tape('disable noise', function (t) {
   const a = new SHP(true, {
     noise: false,
+    encrypted: false,
     onhandshake () {
       t.fail('onhandshake may not be called with noise: false')
     },
@@ -235,6 +236,7 @@ tape('disable noise', function (t) {
 
   const b = new SHP(false, {
     noise: false,
+    encrypted: false,
     onhandshake () {
       t.fail('onhandshake may not be called with noise: false')
     },


### PR DESCRIPTION
This adds an option to disable the NOISE handshake. If `{noise: false}` is passed, the messages will be sent unencrypted and right away without any other handshake data going first. Note that this also disables the capability system (because this only works with the negotiated keys from the NOISE handshake).

See also [hypercore-protocol #50](https://github.com/mafintosh/hypercore-protocol/pull/50) and [hypercore #244](https://github.com/mafintosh/hypercore/pull/244).