### PR TITLE
web application support

### DIFF
--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -93,6 +93,7 @@ function start (self) {
 
 function onsend (err, data) {
   if (err) return this.destroy(err)
+  if (data.constructor === Uint8Array) data = Buffer.from(data);
   const buf = Buffer.allocUnsafe(varint.encodingLength(data.length) + data.length)
   varint.encode(data.length, buf, 0)
   data.copy(buf, varint.encode.bytes)
@@ -101,6 +102,7 @@ function onsend (err, data) {
 
 function onrecv (err, data) { // data is reused so we need to copy it if we use it
   if (err) return this.destroy(err)
+  if (data.constructor === Uint8Array) data = Buffer.from(data);
   if (data && data.length) this.remotePayload = Buffer.concat([data])
   if (this.destroyed || this.noise.finished) return
 
@@ -110,6 +112,7 @@ function onrecv (err, data) { // data is reused so we need to copy it if we use 
 }
 
 function onstatickey (remoteKey, done) {
+  if (remoteKey.constructor === Uint8Array) remoteKey = Buffer.from(remoteKey);
   this.remotePublicKey = Buffer.concat([remoteKey])
   if (this.options.onauthenticate) this.options.onauthenticate(this.remotePublicKey, done)
   else done(null)


### PR DESCRIPTION
I am not sure about the reason but using simple-hypercore-protocol with dazaar to create a react web application I noticed it is necessary to use Buffer.from().

The changes below are sufficient to fix the issue, but probably not the best way to handle it.

Please see working example -> https://github.com/itsdeka/dazaar-react-starter