### PR TITLE
Replace Buffer.concat with Buffer.from to make the library work in browser

### DIFF
--- a/lib/handshake.js
+++ b/lib/handshake.js
@@ -101,7 +101,7 @@ function onsend (err, data) {
 
 function onrecv (err, data) { // data is reused so we need to copy it if we use it
   if (err) return this.destroy(err)
-  if (data && data.length) this.remotePayload = Buffer.concat([data])
+  if (data && data.length) this.remotePayload = Buffer.from(data)
   if (this.destroyed || this.noise.finished) return
 
   if (this.noise.waiting === false) {
@@ -110,7 +110,7 @@ function onrecv (err, data) { // data is reused so we need to copy it if we use 
 }
 
 function onstatickey (remoteKey, done) {
-  this.remotePublicKey = Buffer.concat([remoteKey])
+  this.remotePublicKey = Buffer.from(remoteKey)
   if (this.options.onauthenticate) this.options.onauthenticate(this.remotePublicKey, done)
   else done(null)
 }


### PR DESCRIPTION
When bundling for the browser it looks like the underlying crypto library (`sodium-javascript`) works on `Uint8Array` objects and not Buffers. This causes an error when they get to those `Buffer.concat` calls:

```
Error [TypeError]: "list" argument must be an Array of Buffers
```

I've replaced them with `Buffer.from` which should convert the `Uint8Array` values to instances of `Buffer`.  This should should allow the library to be used in a browsers environment with more configurations and resolve some of the problems mentioned in #5. 

PS: We've created a testing framework to easily run mocha unit-tests in different browsers using playwright. Let me know if you are interested, I can submit a PR.