### PR TITLE
Lock noise-protocol at 3.0.1 to avoid breaking change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "hypercore-crypto": "^2.1.0",
-    "noise-protocol": "^3.0.1",
+    "noise-protocol": "3.0.1",
     "protocol-buffers-encodings": "^1.1.0",
     "simple-handshake": "^3.0.0",
     "simple-message-channels": "^1.2.1",


### PR DESCRIPTION
`noise-protocol@3.0.2` changed the `module.exports` of some of its inner modules from objects to functions. Since this module relies on those internals being objects, the patch release of noise-protocol caused this module to break.

This fix just locks the dependency at the last working version.

This would be helpful to be merged and published as a patch release, so that we (Cabal) don't need to remember to keep pinning noise-protocol at 3.0.1 as a top-level dependency. Thanks!